### PR TITLE
adds small edit to readme to add tauri instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A default template for building Elm applications using Vite. Includes hot-module
 > Elm is a functional language that compiles to JavaScript. It helps you make websites and web apps. It has a strong emphasis on simplicity and quality tooling.
 
 > [UnoCSS](https://github.com/antfu/unocss) is an instant on-demand Atomic CSS engine
-> 
+
+> Tauri is a toolkit that helps developers make applications for the major desktop platforms - using virtually any frontend framework in existence. The core is built with Rust, and the CLI leverages Node.js making Tauri a genuinely polyglot approach to creating and maintaining great apps.
+>
 ## Features
 
 - Hot Module Reload of all code in the app (including Elm)
@@ -21,17 +23,19 @@ A default template for building Elm applications using Vite. Includes hot-module
 
 ```bash
 # Clone the template locally, removing the template's Git log
-npx degit userquin/vite-unocss-elm my-elm-app
+npx degit dit7ya/wk-elm my-app
 
 # Enter the project, install dependencies, and get started!
-cd my-elm-app
-npm install
-npm run dev
+cd my-app
+pnpm install
+pnpm tauri dev
 ```
 
 For more information about Vite, check out [Vite's official documentation.](https://vitejs.dev/)
 
 To learn more about Elm, check out [Elm's official homepage](https://elm-lang.org/).
+
+To learn more about Tauri, check out [Tauri's official homepage](https://tauri.app/).
 
 ## Credits
 


### PR DESCRIPTION
Hey this is template is great! 

I was looking around for how to integrate tauri and elm, and I figured this would be a good place to start. I took me a minute to realize you'd _already_ added tauri. 

I just made an edit to the readme to make it more obvious that it's already got tauri integration. I like nix but I didn't go there.